### PR TITLE
fix(ast, visitors): make parser unwrap let in expressions

### DIFF
--- a/parser/src/test/atom_parser/let_in.rs
+++ b/parser/src/test/atom_parser/let_in.rs
@@ -7,9 +7,8 @@ fn parses_let_in_expression() {
 
     let answ = p.parse("let x = 5 in (x + 1)").unwrap();
     if let Atom::LetIn(let_exp) = answ {
-        let assignment_list = &let_exp.assignments;
-        assert_eq!(assignment_list.len(), 1);
-        assert_eq!(&assignment_list[0].identifier.id, "x");
+        let assignment = &let_exp.assignment;
+        assert_eq!(&assignment.identifier.id, "x");
 
         let body = &let_exp.body;
 
@@ -37,12 +36,14 @@ fn parses_let_in_exp_with_several_assignments() {
 
     let answ = p.parse("let x = 5, y = 10 in (x + y)").unwrap();
     if let Atom::LetIn(let_exp) = answ {
-        let assignment_list = &let_exp.assignments;
-        assert_eq!(assignment_list.len(), 2);
-        assert_eq!(&assignment_list[0].identifier.id, "x");
-        assert_eq!(&assignment_list[1].identifier.id, "y");
+        let first_assignment = &let_exp.assignment;
+        assert_eq!(first_assignment.identifier.id, "x");
 
-        let body = &let_exp.body;
+        let second_assignment = &let_exp.body.as_let_expression().unwrap().assignment;
+        assert_eq!(second_assignment.identifier.id, "y");
+
+
+        let body = &let_exp.body.as_let_expression().unwrap().body;
         let x = &body
             .as_grouped_expression()
             .unwrap()
@@ -67,9 +68,8 @@ fn parses_let_in_exp_with_single_variable_as_output() {
 
     let answ = p.parse("let x = 5 in x").unwrap();
     if let Atom::LetIn(let_exp) = answ {
-        let assignment_list = &let_exp.assignments;
-        assert_eq!(assignment_list.len(), 1);
-        assert_eq!(&assignment_list[0].identifier.id, "x");
+        let assignment = &let_exp.assignment;
+        assert_eq!(&assignment.identifier.id, "x");
 
         let body = &let_exp.body;
         let x = &body.as_identifier().unwrap().id;

--- a/parser/src/tokens/keywords.rs
+++ b/parser/src/tokens/keywords.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use super::*;
 
+#[derive(Clone, Copy)]
 pub enum Keyword {
     Let(TokenPosition),
     If(TokenPosition),

--- a/parser/src/tokens/token_position.rs
+++ b/parser/src/tokens/token_position.rs
@@ -1,3 +1,4 @@
+#[derive(Copy, Clone)]
 pub struct TokenPosition {
     pub start: usize,
     pub end: usize,

--- a/parser/src/visitors/implementations/echo_visitor/echo_visitor.rs
+++ b/parser/src/visitors/implementations/echo_visitor/echo_visitor.rs
@@ -29,24 +29,9 @@ impl Visitor<String> for EchoVisitor {
     }
 
     fn visit_let_in(&mut self, node: &mut crate::ast::LetIn) -> String {
-        let assignments: Vec<String> = node
-            .assignments
-            .iter_mut()
-            .map(|assignment| format!(
-                "{} {} {}",
-                assignment.identifier,
-                assignment.op,
-                assignment.rhs.accept(self)
-            ))
-            .collect();
+        let assignment = node.assignment.accept(self);
         let body = node.body.accept(self);
-        format!(
-            "{} {} {} {}",
-            node.let_token,
-            assignments.join(", "),
-            node.in_token,
-            body
-        )
+        format!("{} {} {} {}", node.let_token, assignment, node.in_token, body)
     }
 
     fn visit_assignment(&mut self, node: &mut crate::ast::Assignment) -> String {

--- a/parser/src/visitors/implementations/echo_visitor/test.rs
+++ b/parser/src/visitors/implementations/echo_visitor/test.rs
@@ -63,6 +63,6 @@ fn echoes_let_in_statement() {
 
     let result = answ.accept(&mut echoer);
 
-    assert_eq!(result, "let x = (1 + 2), y = (x + 2), z = 3 in { ((1 + 2) + (3 / 4)); };");
+    assert_eq!(result, "let x = (1 + 2) in let y = (x + 2) in let z = 3 in { ((1 + 2) + (3 / 4)); };")
 
 }

--- a/parser/src/visitors/implementations/semantic_visitor/semantic_visitor.rs
+++ b/parser/src/visitors/implementations/semantic_visitor/semantic_visitor.rs
@@ -44,14 +44,12 @@ impl Visitor<()> for SemanticVisitor {
     }
 
     fn visit_let_in(&mut self, node: &mut crate::LetIn) {
-        for assignment in &mut node.assignments {
-            self.definitions.push_frame();
-            assignment.accept(self);
-        }
+        self.definitions.push_frame();
+
+        node.assignment.accept(self);
         node.body.accept(self);
-        for _ in &node.assignments {
-            self.definitions.pop_frame();
-        }
+
+        self.definitions.pop_frame();
     }
 
     fn visit_assignment(&mut self, node: &mut crate::Assignment) {


### PR DESCRIPTION
i.e. now let x = 1, x = 2 in x is parsed as nested let in statements, as let x = 1 in let x = 2 in x

make keywords and TokenPosition Copy, so we can use the same let and in tokens for the LetIn structs in these ast nodes