### PR TITLE
fix(codegen): boolean operations fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Session.vim

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,12 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "runner"
 version = "0.1.0"
+dependencies = [
+ "ast",
+ "generator",
+ "parser",
+ "semantic_analyzer",
+]
 
 [[package]]
 name = "rustversion"

--- a/generator/src/llvm_types.rs
+++ b/generator/src/llvm_types.rs
@@ -86,11 +86,11 @@ impl LlvmHandle {
         LlvmHandle::new(HandleType::literal_i1(), llvm_value.to_string())
     }
 
-    pub fn new_tmp_f64_register(name: String) -> LlvmHandle {
+    pub fn new_f64_register(name: String) -> LlvmHandle {
         LlvmHandle::new(HandleType::register_f64(), name)
     }
 
-    pub fn new_tmp_i1_register(name: String) -> LlvmHandle {
+    pub fn new_i1_register(name: String) -> LlvmHandle {
         LlvmHandle::new(HandleType::register_i1(), name)
     }
 }

--- a/generator/src/llvm_types.rs
+++ b/generator/src/llvm_types.rs
@@ -1,10 +1,20 @@
-#[derive(Copy,Clone)]
+#[derive(Copy, Clone)]
 pub enum LlvmType {
     F64,
     I1,
     // this is expected to grow
 }
-#[derive(Copy,Clone)]
+
+impl LlvmType {
+    pub fn llvm_type_str(&self) -> &str {
+        match self {
+            LlvmType::F64 => "double",
+            LlvmType::I1 => "i1",
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
 pub enum HandleType {
     Literal(LlvmType),
     Register(LlvmType),
@@ -24,6 +34,15 @@ impl HandleType {
     pub fn register_i1() -> HandleType {
         HandleType::Register(LlvmType::I1)
     }
+
+    pub fn inner_type(&self) -> LlvmType {
+        match self {
+            HandleType::Register(LlvmType::F64) | HandleType::Literal(LlvmType::F64) => {
+                LlvmType::F64
+            }
+            HandleType::Register(LlvmType::I1) | HandleType::Literal(LlvmType::I1) => LlvmType::I1,
+        }
+    }
 }
 
 /// # Description
@@ -38,6 +57,9 @@ pub struct LlvmHandle {
     pub handle_type: HandleType,
     pub llvm_name: String,
 }
+
+pub const TRUE_LITERAL_STR: &str = "true";
+pub const FALSE_LITERAL_STR: &str = "false";
 
 impl LlvmHandle {
     pub fn new(handle_type: HandleType, handle: String) -> LlvmHandle {
@@ -56,7 +78,11 @@ impl LlvmHandle {
     }
 
     pub fn new_i1_literal(value: bool) -> LlvmHandle {
-        let llvm_value = if value { "true" } else { "false" };
+        let llvm_value = if value {
+            TRUE_LITERAL_STR.to_string()
+        } else {
+            FALSE_LITERAL_STR.to_string()
+        };
         LlvmHandle::new(HandleType::literal_i1(), llvm_value.to_string())
     }
 

--- a/generator/src/test/booleans.rs
+++ b/generator/src/test/booleans.rs
@@ -42,3 +42,69 @@ fn boolean_operations2() {
 
     assert_eq!(result, expected);
 }
+
+#[test]
+fn test_true_literal() {
+    let llvm = generate_code("print(true);");
+    println!("{}", llvm);
+
+    let true_literal = lli_i1(&llvm).unwrap();
+    assert_eq!(true_literal, true);
+}
+
+#[test]
+fn test_true_result() {
+    let llvm = generate_code("print(true || true && false);");
+    println!("{}", llvm);
+
+    let true_result = lli_i1(&llvm).unwrap();
+    assert_eq!(true_result, true);
+}
+
+#[test]
+fn test_false_literal() {
+    let llvm = generate_code("print(false);");
+    println!("{}", llvm);
+
+    let false_literal = lli_i1(&llvm).unwrap();
+    assert_eq!(false_literal, false);
+}
+
+#[test]
+fn test_false_result() {
+    let llvm = generate_code("print(false || true && false);");
+    println!("{}", llvm);
+
+    let false_result = lli_i1(&llvm).unwrap();
+    assert_eq!(false_result, false);
+}
+
+#[test]
+fn test_composite_boolean_expression() {
+    let llvm = generate_code(
+        "
+        let x = 5, y = 10, z = 15 in
+        print(((x < y) && (y < z) || (x > z)) == true);",
+    );
+
+    println!("{}", llvm);
+
+    let result = lli_i1(&llvm).unwrap();
+    let expected = true;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_composite_boolean_expression2() {
+    let llvm = generate_code(
+        "
+        print(5 < 3 || 2 == 2 && true == false || 1 != 0);
+        ",
+    );
+
+    println!("{}", llvm);
+
+    let result = lli_i1(&llvm).unwrap();
+    let expected = true;
+    assert_eq!(result, expected);
+}

--- a/generator/src/test/if_else.rs
+++ b/generator/src/test/if_else.rs
@@ -4,7 +4,7 @@ use crate::test::{generate_code, lli_interface::lli_f64};
 fn test_if_else() {
     let llvm = generate_code(
         "let x = 
-            if (0) 
+            if (false) 
                 { 1; } 
             else { 
                 let x = 2 in {
@@ -25,7 +25,7 @@ fn test_if_else() {
 fn using_variable_in_definition() {
     let llvm = generate_code(
         "let x = 
-            if (0) 
+            if (false) 
                 { 1; }
             else { 
                 x := x + 1;

--- a/generator/src/test/lli_interface.rs
+++ b/generator/src/test/lli_interface.rs
@@ -29,10 +29,10 @@ pub fn lli_f64(program_str: &str) -> Result<f64, String> {
 
 pub fn lli_i1(program_str: &str) -> Result<bool, String> {
     let value = call_lli(program_str)?;
-    print!("{}",value);
+    print!("{}", value);
     match value.trim() {
-        "1" => Ok(true),
-        "0" => Ok(false),
+        "true" => Ok(true),
+        "false" => Ok(false),
         _ => Err(format!("Unexpected boolean output: {}", value)),
     }
 }

--- a/generator/src/test/misc.rs
+++ b/generator/src/test/misc.rs
@@ -5,7 +5,7 @@ fn fibonacci_numbers() {
     let llvm = generate_code(
         "let x = 10 in {
           let a = 0, b = 0, fib = 1 in {
-              while(x - 1) {
+              while(x != 1) {
                   a := b;
                   b := fib;
                   fib := a + b;

--- a/generator/src/test/printer.rs
+++ b/generator/src/test/printer.rs
@@ -4,7 +4,7 @@ use crate::test::{generate_code, lli_interface::call_lli};
 fn printer() {
     let llvm = generate_code(
         "let x = 10 in {
-            while(x - 1) {
+            while(x < 1) {
                 x := x - 1;
                 print(x);
             };

--- a/generator/src/test/while_loop.rs
+++ b/generator/src/test/while_loop.rs
@@ -6,7 +6,7 @@ use super::generate_code;
 fn simple() {
     let llvm = generate_code(
         "let x = 10 in {
-            while(x - 1) {
+            while(x != 1) {
                 x := x - 1;
             };
             print(x);

--- a/generator/src/visitor.rs
+++ b/generator/src/visitor.rs
@@ -1,14 +1,30 @@
+mod assignment;
+mod bin_op;
+mod if_else;
+mod print;
+mod un_op;
+mod while_exp;
+
+mod helpers {
+    pub mod control_flow;
+    pub mod variables;
+}
+
 use std::collections::HashMap;
 
 use crate::context::Context;
-use crate::llvm_types;
-use crate::llvm_types::{HandleType, LlvmHandle, LlvmType};
-use ast::BinaryOperator::*;
+use crate::llvm_types::{LlvmHandle, LlvmType};
 use ast::{Visitor, visitors::visitable::Visitable};
 
 pub struct VisitorResult {
     pub result_handle: Option<LlvmHandle>,
     pub preamble: String,
+}
+
+impl VisitorResult {
+    pub fn has_null_result(&self) -> bool {
+        matches!(self.result_handle, None)
+    }
 }
 
 struct Variable {
@@ -64,373 +80,12 @@ impl GeneratorVisitor {
             variable_ids: HashMap::new(),
         }
     }
-
-    pub fn generate_tmp_variable(&mut self) -> String {
-        // we use the . after % to get around llvm's requirement that %N names
-        // be sequential starting at 0 within the same context
-        let tmp_variable = format!("%.{}", self.tmp_variable_id);
-        self.tmp_variable_id += 1;
-
-        tmp_variable
-    }
-
-    /// # Description
-    ///
-    /// Uses the same global tmp_variable id to create globally unique then, else, fi
-    /// labels, used for if expressions
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use generator::GeneratorVisitor;
-    /// let mut cg = GeneratorVisitor::new();
-    ///
-    /// let (t, e, f) = cg.generate_then_else_fi_labels();
-    ///
-    /// assert_eq!(t, "then.0");
-    /// assert_eq!(e, "else.0");
-    /// assert_eq!(f, "fi.0");
-    /// ```
-    ///
-    /// ```rust
-    /// use generator::GeneratorVisitor;
-    /// let mut cg = GeneratorVisitor::new();
-    ///
-    /// let a = cg.generate_tmp_variable(); // %.0
-    /// let (t, e, f) = cg.generate_then_else_fi_labels();
-    ///
-    /// assert_eq!(t, "then.1");
-    /// assert_eq!(e, "else.1");
-    /// assert_eq!(f, "fi.1");
-    /// ```
-    ///
-    pub fn generate_then_else_fi_labels(&mut self) -> (String, String, String) {
-        let t = format!("then.{}", self.tmp_variable_id);
-        let e = format!("else.{}", self.tmp_variable_id);
-        let f = format!("fi.{}", self.tmp_variable_id);
-
-        self.tmp_variable_id += 1;
-
-        (t, e, f)
-    }
-
-    /// # Description
-    ///
-    /// Uses the same global tmp_variable id to create globally unique loop, body,
-    /// loop_exit labels
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use generator::GeneratorVisitor;
-    /// let mut cg = GeneratorVisitor::new();
-    ///
-    /// let (l, b, le) = cg.generate_loop_labels();
-    ///
-    /// assert_eq!(l, "loop.0");
-    /// assert_eq!(b, "body.0");
-    /// assert_eq!(le, "loop_exit.0");
-    /// ```
-    ///
-    /// ```rust
-    /// use generator::GeneratorVisitor;
-    /// let mut cg = GeneratorVisitor::new();
-    ///
-    /// let a = cg.generate_tmp_variable(); // %.0
-    /// let (l, b, le) = cg.generate_loop_labels();
-    ///
-    /// assert_eq!(l, "loop.1");
-    /// assert_eq!(b, "body.1");
-    /// assert_eq!(le, "loop_exit.1");
-    /// ```
-    ///
-    pub fn generate_loop_labels(&mut self) -> (String, String, String) {
-        let l = format!("loop.{}", self.tmp_variable_id);
-        let b = format!("body.{}", self.tmp_variable_id);
-        let le = format!("loop_exit.{}", self.tmp_variable_id);
-
-        self.tmp_variable_id += 1;
-
-        (l, b, le)
-    }
-
-    /// # Description
-    ///
-    /// Increases the globally unique id for this variable name, defines it
-    /// using its name in the current context, and assigning to it the unique
-    /// generated llvm name
-    ///
-    /// Returns the newly generated llvm name
-    ///
-    /// # Example
-    ///
-    /// The first generated name for a hulk variable `x` would for example be
-    /// `%x.0`, the second, `%x.1`, this way, even if we enter and leave contexts,
-    /// we do not need to have the concept of blocks in llvm
-    pub fn define_or_shadow(&mut self, name: String, handle_type: LlvmType) -> String {
-        let id: i32;
-        {
-            id = *self.variable_ids.get(&name).unwrap_or(&0);
-        }
-        self.variable_ids.insert(name.clone(), id + 1);
-
-        let llvm_name = format!("%{}.{}", name, id);
-
-        match handle_type {
-            LlvmType::F64 => {
-                self.context
-                    .define(name, Variable::new_f64(llvm_name.clone()));
-            }
-            LlvmType::I1 => {
-                self.context
-                    .define(name, Variable::new_i1(llvm_name.clone()));
-            }
-        }
-
-        return llvm_name;
-    }
-
-    /// # Description
-    ///
-    /// This will be used internally to create a visitor result when the
-    /// lhs of a unary operator is double, to not fill the visit_unop
-    /// function with too much code.
-    ///
-    /// It is assumed if the lhs is double then the rhs will also be double,
-    /// this is a guarantee of SA
-    ///
-    /// # Panics
-    ///
-    /// - If the inner result handle is None or if the
-    /// operator is not supported by double values
-    fn get_double_un_op_visitor_result(
-        &mut self,
-        op: &ast::UnaryOperator,
-        inner_result: VisitorResult,
-    ) -> VisitorResult {
-        let inner_handle = inner_result.result_handle.unwrap();
-
-        match op {
-            ast::UnaryOperator::Plus(_) => {
-                return VisitorResult {
-                    preamble: inner_result.preamble,
-                    result_handle: Some(inner_handle),
-                };
-            }
-            ast::UnaryOperator::Minus(_) => {
-                let tmp_variable = self.generate_tmp_variable();
-                let preamble = inner_result.preamble
-                    + "\n"
-                    + &format!(
-                        "{} = fsub double 0.0, {}",
-                        tmp_variable, inner_handle.llvm_name
-                    );
-
-                return VisitorResult {
-                    preamble,
-                    result_handle: Some(LlvmHandle::new_tmp_f64_register(tmp_variable)),
-                };
-            }
-            _ => panic!("Unsupported unary operator for double"),
-        }
-    }
-
-    fn get_boolean_un_op_visitor_result(
-        &mut self,
-        op: &ast::UnaryOperator,
-        inner_result: VisitorResult,
-    ) -> VisitorResult {
-        let inner_handle = inner_result.result_handle.unwrap();
-
-        match op {
-            ast::UnaryOperator::Not(_) => {
-                let tmp_variable = self.generate_tmp_variable();
-                let preamble = inner_result.preamble
-                    + "\n"
-                    + &format!("{} = xor i1 {}, true", tmp_variable, inner_handle.llvm_name);
-
-                return VisitorResult {
-                    preamble,
-                    result_handle: Some(LlvmHandle::new_tmp_i1_register(tmp_variable)),
-                };
-            }
-            _ => panic!("Unsupported unary operator for boolean"),
-        }
-    }
-
-    /// # Description
-    ///
-    /// This will be used internally to create a visitor result when the
-    /// operands of a binary operator are doubles, to not fill the
-    /// visit_bin_op handler with code
-    ///
-    /// # Panics
-    ///
-    /// - If eiher of the operand handles are None or the operator is
-    /// not supported for double values
-    fn get_double_bin_op_visitor_result(
-        &mut self,
-        op: &ast::BinaryOperator,
-        lhs: VisitorResult,
-        rhs: VisitorResult,
-    ) -> VisitorResult {
-        let rhs_handle = rhs.result_handle.unwrap();
-        let lhs_handle = lhs.result_handle.unwrap();
-
-        let preamble = lhs.preamble + &rhs.preamble;
-
-        let result_handle = self.generate_tmp_variable();
-
-        let operation = match op {
-            Plus(_) => format!(
-                "{} = fadd double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            Minus(_) => format!(
-                "{} = fsub double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            Times(_) => format!(
-                "{} = fmul double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            Divide(_) => format!(
-                "{} = fdiv double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            FloorDivide(_) => todo!(),
-            Modulo(_) => todo!(),
-            Equal(_) => panic!("= found in non-assignment, parser problem"),
-            ColonEqual(_) => panic!(":= found in non-destructive assignment, parser problem"),
-            EqualEqual(_) => format!(
-                "{} = fcmp oeq double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            NotEqual(_) => format!(
-                "{} = fcmp one double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            Less(_) => format!(
-                "{} = fcmp olt double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            LessEqual(_) => format!(
-                "{} = fcmp ole double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            Greater(_) => format!(
-                "{} = fcmp ogt double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            GreaterEqual(_) => format!(
-                "{} = fcmp oge double {}, {}",
-                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            _ => panic!("Unsupported numeric operator"),
-        } + "\n";
-
-        let result_handle = match op {
-            EqualEqual(_) | NotEqual(_) | Less(_) | LessEqual(_) | Greater(_) | GreaterEqual(_) => {
-                Some(LlvmHandle::new_tmp_i1_register(result_handle))
-            }
-
-            Plus(_) | Minus(_) | Times(_) | Divide(_) | FloorDivide(_) | Modulo(_) => {
-                Some(LlvmHandle::new_tmp_f64_register(result_handle))
-            }
-
-            Equal(_) => panic!("= found in non-assignment, parser problem"),
-            ColonEqual(_) => panic!(":= found in non-destructive assignment, parser problem"),
-
-            _ => panic!("Unsupported numeric operator"),
-        };
-
-        VisitorResult {
-            preamble: preamble + &operation,
-            result_handle,
-        }
-    }
-
-    fn get_boolean_bin_op_visitor_result(
-        &mut self,
-        op: &ast::BinaryOperator,
-        lhs: VisitorResult,
-        rhs: VisitorResult,
-    ) -> VisitorResult {
-        let lhs_handle = lhs.result_handle.unwrap();
-        let rhs_handle = rhs.result_handle.unwrap();
-        let result_register = self.generate_tmp_variable();
-
-        let operation = match op {
-            And(_) => format!(
-                "{} = and i1 {}, {}\n",
-                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            Or(_) => format!(
-                "{} = or i1 {}, {}\n",
-                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            EqualEqual(_) => format!(
-                "{} = icmp eq i1 {}, {}\n",
-                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            NotEqual(_) => format!(
-                "{} = icmp ne i1 {}, {}\n",
-                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
-            ),
-            _ => panic!("Unsupported boolean operator"),
-        } + "\n";
-
-        VisitorResult {
-            preamble: lhs.preamble + &rhs.preamble + &operation,
-            result_handle: Some(LlvmHandle::new_tmp_i1_register(result_register)),
-        }
-    }
-
-    fn print_true(&mut self) -> String {
-        let element_ptr = self.generate_tmp_variable();
-        format!(
-            "{} = getelementptr [5 x i8], [5 x i8]* @.true_str, i32 0, i32 0\n",
-            element_ptr
-        ) + &format!("call i32 (i8*, ...) @printf(i8* {})\n", element_ptr)
-    }
-
-    fn print_false(&mut self) -> String {
-        let element_ptr = self.generate_tmp_variable();
-        format!(
-            "{} = getelementptr [6 x i8], [6 x i8]* @.false_str, i32 0, i32 0\n",
-            element_ptr
-        ) + &format!("call i32 (i8*, ...) @printf(i8* {})\n", element_ptr)
-    }
-
-    fn print_boolean_register(&mut self, handle: &str) -> String {
-        let (then, else_, fi) = self.generate_then_else_fi_labels();
-        format!("br i1 {handle}, label %{then}, label %{else_}\n")
-            + &format!("{then}:\n")
-            + &self.print_true()
-            + &format!("br label %{fi}\n")
-            + &format!("{else_}:\n")
-            + &self.print_false()
-            + &format!("br label %{fi}\n")
-            + &format!("{fi}:\n")
-    }
-
-    fn print_none(&mut self) -> String {
-        let element_ptr = self.generate_tmp_variable();
-        format!(
-            "{} = getelementptr [5 x i8], [5 x i8]* @.none_str, i32 0, i32 0\n",
-            element_ptr
-        ) + &format!("call i32 (i8*, ...) @printf(i8* {})\n", element_ptr)
-    }
 }
 
 impl Visitor<VisitorResult> for GeneratorVisitor {
     fn visit_program(&mut self, node: &mut ast::Program) -> VisitorResult {
-        let mut program = "@.fstr = private constant [3 x i8] c\"%f\\00\", align 1\n".to_string()
-            + "@.true_str = private constant [5 x i8] c\"true\\00\", align 1\n"
-            + "@.false_str = private constant [6 x i8] c\"false\\00\", align 1\n"
-            + "@.none_str = private constant [5 x i8] c\"none\\00\", align 1\n"
-            + "declare i32 @printf(i8*, ...)\n"
-            + "define i32 @main() {\nentry:\n";
+        let mut program =
+            self.instantiate_global_print_helpers() + "define i32 @main() {\nentry:\n";
 
         let inner = node.expression_list.accept(self);
 
@@ -476,11 +131,11 @@ impl Visitor<VisitorResult> for GeneratorVisitor {
         let expression_result = node.expression.accept(self);
         let mut preamble = expression_result.preamble;
 
-        let result_handle = expression_result.result_handle.expect(
+        let exp_result_handle = expression_result.result_handle.expect(
             "Variable must be dassigned to non-null expression result, SA should've caught this",
         );
 
-        let llvm_name = &self
+        let var_llvm_name = &self
             .context
             .get_value(&node.identifier.id)
             .expect(
@@ -492,49 +147,23 @@ impl Visitor<VisitorResult> for GeneratorVisitor {
             )
             .llvm_name;
 
-        match result_handle.handle_type {
-            HandleType::Literal(LlvmType::F64) | HandleType::Register(LlvmType::F64) => {
-                preamble = preamble
-                    + &format!(
-                        "store double {}, double* {}, align 8\n",
-                        result_handle.llvm_name, llvm_name
-                    )
-            }
-            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
-                preamble = preamble
-                    + &format!(
-                        "store i1 {}, i1* {}, align 1\n",
-                        result_handle.llvm_name, llvm_name
-                    );
-            }
-        };
+        preamble += &self.store_statement(
+            &exp_result_handle.llvm_name,
+            &var_llvm_name,
+            &exp_result_handle.handle_type.inner_type(),
+        );
 
         VisitorResult {
             preamble,
-            result_handle: Some(result_handle),
+            result_handle: Some(exp_result_handle),
         }
     }
 
     fn visit_bin_op(&mut self, node: &mut ast::BinOp) -> VisitorResult {
-        let left_result = node.lhs.accept(self);
-        if left_result.result_handle.is_none() {
-            panic!("Expected a result handle for lhs of binary operator");
-        }
+        let lhs_result = node.lhs.accept(self);
+        let rhs_result = node.rhs.accept(self);
 
-        let right_result = node.rhs.accept(self);
-        if right_result.result_handle.is_none() {
-            panic!("Expected a result handle for rhs of binary operator");
-        }
-
-        // equal types for each operand is a guarantee of SA
-        match left_result.result_handle.as_ref().unwrap().handle_type {
-            HandleType::Literal(LlvmType::F64) | HandleType::Register(LlvmType::F64) => {
-                return self.get_double_bin_op_visitor_result(&node.op, left_result, right_result);
-            }
-            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
-                return self.get_boolean_bin_op_visitor_result(&node.op, left_result, right_result);
-            }
-        };
+        self.handle_bin_op(lhs_result, rhs_result, &node.op)
     }
 
     fn visit_atom(&mut self, node: &mut ast::Atom) -> VisitorResult {
@@ -558,241 +187,30 @@ impl Visitor<VisitorResult> for GeneratorVisitor {
 
     fn visit_assignment(&mut self, node: &mut ast::Assignment) -> VisitorResult {
         let expression_result = node.rhs.accept(self);
-        let mut preamble = expression_result.preamble;
-        let result_handle = expression_result.result_handle.expect(
-            "Variable must be assigned to non-null expression result, SA should've caught this",
-        );
 
-        let llvm_name = self.define_or_shadow(
-            node.identifier.id.clone(),
-            result_handle.handle_type.inner_type(),
-        );
-
-        match result_handle.handle_type {
-            HandleType::Literal(LlvmType::F64) | HandleType::Register(LlvmType::F64) => {
-                preamble = preamble
-                    + &format!("{} = alloca double, align 8\n", llvm_name)
-                    + &format!(
-                        "store double {}, double* {}, align 8\n",
-                        result_handle.llvm_name, llvm_name
-                    )
-            }
-            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
-                preamble = preamble
-                    + &format!("{} = alloca i1, align 1\n", llvm_name)
-                    + &format!(
-                        "store i1 {}, i1* {}, align 1\n",
-                        result_handle.llvm_name, llvm_name
-                    );
-            }
-        };
-
-        VisitorResult {
-            preamble,
-            result_handle: None,
-        }
+        self.handle_assignment(node.identifier.id.clone(), expression_result)
     }
 
     fn visit_if_else(&mut self, node: &mut ast::IfElse) -> VisitorResult {
-        let (then_label, else_label, fi_label) = self.generate_then_else_fi_labels();
-
         let condition_result = node.condition.accept(self);
-        let condition_handle = condition_result
-            .result_handle
-            .expect("Expected a result handle for condition of if expression");
 
         let then_result = node.then_expression.accept(self);
         let else_result = node.else_expression.accept(self);
 
-        let (result_variable, result_register, result_type) = match then_result.result_handle {
-            Some(ref handle) => (
-                Some(self.generate_tmp_variable()),
-                Some(self.generate_tmp_variable()),
-                Some(handle.handle_type),
-            ),
-
-            // this can happen if the then block is empty, or is multiple semicolon
-            // terminated, we also assume the else block is empty in this case, SA
-            // must guarantee this
-            None => (None, None, None),
-        };
-
-        let format_result_store =
-            |branch_result_handle: Option<LlvmHandle>| match (branch_result_handle, &result_type) {
-                (
-                    Some(ref name),
-                    Some(HandleType::Literal(LlvmType::F64))
-                    | Some(HandleType::Register(LlvmType::F64)),
-                ) => format!(
-                    "store double {}, double* {}, align 8\n",
-                    name.llvm_name,
-                    result_variable.as_ref().unwrap()
-                ),
-                (
-                    Some(ref name),
-                    Some(HandleType::Literal(LlvmType::I1))
-                    | Some(HandleType::Register(LlvmType::I1)),
-                ) => format!(
-                    "store i1 {}, i1* {}, align 1\n",
-                    name.llvm_name,
-                    result_variable.as_ref().unwrap()
-                ),
-                _ => "".to_string(),
-            };
-
-        let result_alloca_statement = match (&result_variable, &result_type) {
-            (
-                Some(name),
-                Some(HandleType::Literal(LlvmType::F64))
-                | Some(HandleType::Register(LlvmType::F64)),
-            ) => {
-                format!("{} = alloca double, align 8\n", name)
-            }
-            (
-                Some(name),
-                Some(HandleType::Literal(LlvmType::I1)) | Some(HandleType::Register(LlvmType::I1)),
-            ) => {
-                format!("{} = alloca i1, align 1\n", name)
-            }
-            _ => "".to_string(),
-        };
-
-        let result_load_statement = match (&result_register, &result_variable, &result_type) {
-            (
-                Some(reg),
-                Some(var),
-                Some(HandleType::Literal(LlvmType::F64))
-                | Some(HandleType::Register(LlvmType::F64)),
-            ) => {
-                format!("{} = load double, double* {}, align 8\n", reg, var)
-            }
-            (
-                Some(reg),
-                Some(var),
-                Some(HandleType::Literal(LlvmType::I1)) | Some(HandleType::Register(LlvmType::I1)),
-            ) => {
-                format!("{} = load i1, i1* {}, align 1\n", reg, var)
-            }
-            _ => "".to_string(),
-        };
-
-        let mut branch_setup = condition_result.preamble;
-
-        match condition_handle.handle_type {
-            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
-                branch_setup = branch_setup
-                    + &result_alloca_statement
-                    + &format!(
-                        "br i1 {}, label %{}, label %{}\n",
-                        condition_handle.llvm_name, then_label, else_label
-                    );
-            }
-            _ => panic!("Expected a boolean handle for condition of if expression"),
-        };
-
-        let format_branch = |branch_name, preamble, result_handle: Option<LlvmHandle>| {
-            format!(
-                "{}:\n{}",
-                branch_name,
-                preamble
-                    + format_result_store(result_handle).as_str()
-                    + format!("br label %{}\n", fi_label).as_str()
-            )
-        };
-
-        let then_code = format_branch(then_label, then_result.preamble, then_result.result_handle);
-        let else_code = format_branch(else_label, else_result.preamble, else_result.result_handle);
-
-        let preamble = branch_setup
-            + &then_code
-            + &else_code
-            + &format!("{}:\n", fi_label)
-            + &result_load_statement;
-
-        VisitorResult {
-            preamble,
-            result_handle: result_register.zip(result_type).map(|(name, ht)| match ht {
-                HandleType::Register(LlvmType::F64) | HandleType::Literal(LlvmType::F64) => {
-                    LlvmHandle::new_tmp_f64_register(name)
-                }
-                HandleType::Register(LlvmType::I1) | HandleType::Literal(LlvmType::I1) => {
-                    LlvmHandle::new_tmp_i1_register(name)
-                }
-            }),
-        }
+        self.handle_if_else(condition_result, then_result, else_result)
     }
 
     fn visit_print(&mut self, node: &mut ast::Print) -> VisitorResult {
         let inner_result = node.expression.accept(self);
 
-        let preamble = inner_result.preamble
-            + &match inner_result.result_handle {
-                Some(handle) => match handle.handle_type {
-                    HandleType::Register(LlvmType::F64) | HandleType::Literal(LlvmType::F64) => {
-                        let element_ptr_variable = self.generate_tmp_variable();
-
-                        format!(
-                            "{} = getelementptr inbounds [3 x i8], [3 x i8]* @.fstr, i32 0, i32 0\ncall i32 (i8*, ...) @printf(i8* {}, double {})",
-                            element_ptr_variable, element_ptr_variable, handle.llvm_name
-                        )
-                    }
-                    HandleType::Literal(LlvmType::I1) => {
-                        if handle.llvm_name == llvm_types::TRUE_LITERAL_STR {
-                            self.print_true()
-                        } else {
-                            self.print_false()
-                        }
-                    }
-                    HandleType::Register(LlvmType::I1) => {
-                        self.print_boolean_register(&handle.llvm_name)
-                    }
-                },
-                None => self.print_none(),
-            };
-
-        VisitorResult {
-            preamble,
-            result_handle: None,
-        }
+        self.handle_print(inner_result)
     }
 
     fn visit_while(&mut self, node: &mut ast::While) -> VisitorResult {
         let condition_result = node.condition.accept(self);
-        let condition_result_handle = condition_result
-            .result_handle
-            .expect("Expected a result handle for condition of while statement");
-
         let body_result = node.body.accept(self);
 
-        let (loop_label, body_label, loop_exit_label) = self.generate_loop_labels();
-
-        let mut loop_setup_code = format!("br label %{}\n", loop_label)
-            + &format!("{}:\n", loop_label)
-            + &condition_result.preamble;
-
-        match condition_result_handle.handle_type {
-            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
-                loop_setup_code = loop_setup_code
-                    + &format!(
-                        "br i1 {}, label %{}, label %{}\n",
-                        condition_result_handle.llvm_name, body_label, loop_exit_label
-                    );
-            }
-            _ => panic!("Expected a boolean handle for condition of if expression"),
-        };
-
-        let body_code = format!("{}:\n", body_label)
-            + &body_result.preamble
-            + &format!("br label %{}\n", loop_label);
-
-        let loop_exit_code = format!("{}:\n", loop_exit_label);
-
-        let preamble = loop_setup_code + &body_code + &loop_exit_code;
-
-        VisitorResult {
-            preamble,
-            result_handle: None,
-        }
+        self.handle_while(condition_result, body_result)
     }
 
     fn visit_block(&mut self, node: &mut ast::Block) -> VisitorResult {
@@ -805,18 +223,8 @@ impl Visitor<VisitorResult> for GeneratorVisitor {
 
     fn visit_un_op(&mut self, node: &mut ast::UnOp) -> VisitorResult {
         let inner_result = node.rhs.accept(self);
-        if inner_result.result_handle.is_none() {
-            panic!("Expected a result handle for operand of unary operator");
-        }
 
-        match inner_result.result_handle.as_ref().unwrap().handle_type {
-            HandleType::Literal(LlvmType::F64) | HandleType::Register(LlvmType::F64) => {
-                self.get_double_un_op_visitor_result(&node.op, inner_result)
-            }
-            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
-                self.get_boolean_un_op_visitor_result(&node.op, inner_result)
-            }
-        }
+        self.handle_un_op(inner_result, &node.op)
     }
 
     fn visit_variable(&mut self, node: &mut ast::Identifier) -> VisitorResult {
@@ -827,30 +235,16 @@ impl Visitor<VisitorResult> for GeneratorVisitor {
             .get_value(&node.id)
             .expect(format!("Variable {} not found, SA should have caught this", node.id).as_str());
 
-        match variable.var_type {
-            LlvmType::F64 => {
-                let preamble = format!(
-                    "{} = load double, double* {}, align 8\n",
-                    register_name, variable.llvm_name
-                );
+        let (preamble, result_handle) = self.extract_variable_value_to_register(
+            register_name,
+            &variable.llvm_name,
+            &variable.var_type,
+        );
 
-                return VisitorResult {
-                    preamble,
-                    result_handle: Some(LlvmHandle::new_tmp_f64_register(register_name)),
-                };
-            }
-            LlvmType::I1 => {
-                let preamble = format!(
-                    "{} = load i1, i1* {}, align 1\n",
-                    register_name, variable.llvm_name
-                );
-
-                VisitorResult {
-                    preamble,
-                    result_handle: Some(LlvmHandle::new_tmp_i1_register(register_name)),
-                }
-            }
-        }
+        return VisitorResult {
+            preamble,
+            result_handle: Some(result_handle),
+        };
     }
 
     fn visit_number_literal(&mut self, node: &mut ast::NumberLiteral) -> VisitorResult {

--- a/generator/src/visitor/assignment.rs
+++ b/generator/src/visitor/assignment.rs
@@ -1,0 +1,68 @@
+use crate::llvm_types::LlvmType;
+
+use super::{GeneratorVisitor, Variable, VisitorResult};
+
+impl GeneratorVisitor {
+    pub(crate) fn handle_assignment(
+        &mut self,
+        identifier: String,
+        expression_result: VisitorResult,
+    ) -> VisitorResult {
+        let mut preamble = expression_result.preamble;
+        let result_handle = expression_result.result_handle.expect(
+            "Variable must be assigned to non-null expression result, SA should've caught this",
+        );
+
+        let var_llvm_name =
+            self.define_or_shadow(identifier, result_handle.handle_type.inner_type());
+
+        preamble = preamble
+            + &self.alloca_statement(&var_llvm_name, &result_handle.handle_type.inner_type())
+            + &self.store_statement(
+                &result_handle.llvm_name,
+                &var_llvm_name,
+                &result_handle.handle_type.inner_type(),
+            );
+
+        VisitorResult {
+            preamble,
+            result_handle: None,
+        }
+    }
+
+    /// # Description
+    ///
+    /// Increases the globally unique id for this variable name, defines it
+    /// using its name in the current context, and assigning to it the unique
+    /// generated llvm name
+    ///
+    /// Returns the newly generated llvm name
+    ///
+    /// # Examples
+    ///
+    /// The first generated name for a hulk variable `x` would for example be
+    /// `%x.0`, the second, `%x.1`, this way, even if we enter and leave contexts,
+    /// we do not need to have the concept of blocks in llvm
+    fn define_or_shadow(&mut self, name: String, handle_type: LlvmType) -> String {
+        let id: i32;
+        {
+            id = *self.variable_ids.get(&name).unwrap_or(&0);
+        }
+        self.variable_ids.insert(name.clone(), id + 1);
+
+        let llvm_name = format!("%{}.{}", name, id);
+
+        match handle_type {
+            LlvmType::F64 => {
+                self.context
+                    .define(name, Variable::new_f64(llvm_name.clone()));
+            }
+            LlvmType::I1 => {
+                self.context
+                    .define(name, Variable::new_i1(llvm_name.clone()));
+            }
+        }
+
+        return llvm_name;
+    }
+}

--- a/generator/src/visitor/bin_op.rs
+++ b/generator/src/visitor/bin_op.rs
@@ -1,0 +1,161 @@
+use ast::BinaryOperator;
+use ast::BinaryOperator::*;
+
+use crate::llvm_types::{HandleType, LlvmHandle, LlvmType};
+
+use super::{GeneratorVisitor, VisitorResult};
+
+impl GeneratorVisitor {
+    pub(crate) fn handle_bin_op(
+        &mut self,
+        lhs_result: VisitorResult,
+        rhs_result: VisitorResult,
+        op: &BinaryOperator,
+    ) -> VisitorResult {
+        if lhs_result.result_handle.is_none() {
+            panic!("Expected a result handle for lhs of binary operator");
+        }
+
+        if rhs_result.result_handle.is_none() {
+            panic!("Expected a result handle for rhs of binary operator");
+        }
+
+        // equal types for each operand is a guarantee of SA
+        match lhs_result.result_handle.as_ref().unwrap().handle_type {
+            HandleType::Literal(LlvmType::F64) | HandleType::Register(LlvmType::F64) => {
+                return self.get_double_bin_op_visitor_result(op, lhs_result, rhs_result);
+            }
+            HandleType::Literal(LlvmType::I1) | HandleType::Register(LlvmType::I1) => {
+                return self.get_boolean_bin_op_visitor_result(op, lhs_result, rhs_result);
+            }
+        };
+    }
+
+    /// # Description
+    ///
+    /// This will be used internally to create a visitor result when the
+    /// operands of a binary operator are doubles, to not fill the
+    /// visit_bin_op handler with code
+    ///
+    /// # Panics
+    ///
+    /// - If eiher of the operand handles are None or the operator is
+    /// not supported for double values
+    fn get_double_bin_op_visitor_result(
+        &mut self,
+        op: &ast::BinaryOperator,
+        lhs: VisitorResult,
+        rhs: VisitorResult,
+    ) -> VisitorResult {
+        let rhs_handle = rhs.result_handle.unwrap();
+        let lhs_handle = lhs.result_handle.unwrap();
+
+        let preamble = lhs.preamble + &rhs.preamble;
+
+        let result_handle = self.generate_tmp_variable();
+
+        let operation = match op {
+            Plus(_) => format!(
+                "{} = fadd double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            Minus(_) => format!(
+                "{} = fsub double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            Times(_) => format!(
+                "{} = fmul double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            Divide(_) => format!(
+                "{} = fdiv double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            FloorDivide(_) => todo!(),
+            Modulo(_) => todo!(),
+            Equal(_) => panic!("= found in non-assignment, parser problem"),
+            ColonEqual(_) => panic!(":= found in non-destructive assignment, parser problem"),
+            EqualEqual(_) => format!(
+                "{} = fcmp oeq double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            NotEqual(_) => format!(
+                "{} = fcmp one double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            Less(_) => format!(
+                "{} = fcmp olt double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            LessEqual(_) => format!(
+                "{} = fcmp ole double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            Greater(_) => format!(
+                "{} = fcmp ogt double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            GreaterEqual(_) => format!(
+                "{} = fcmp oge double {}, {}",
+                result_handle, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            _ => panic!("Unsupported numeric operator"),
+        } + "\n";
+
+        let result_handle = match op {
+            EqualEqual(_) | NotEqual(_) | Less(_) | LessEqual(_) | Greater(_) | GreaterEqual(_) => {
+                Some(LlvmHandle::new_i1_register(result_handle))
+            }
+
+            Plus(_) | Minus(_) | Times(_) | Divide(_) | FloorDivide(_) | Modulo(_) => {
+                Some(LlvmHandle::new_f64_register(result_handle))
+            }
+
+            Equal(_) => panic!("= found in non-assignment, parser problem"),
+            ColonEqual(_) => panic!(":= found in non-destructive assignment, parser problem"),
+
+            _ => panic!("Unsupported numeric operator"),
+        };
+
+        VisitorResult {
+            preamble: preamble + &operation,
+            result_handle,
+        }
+    }
+
+    fn get_boolean_bin_op_visitor_result(
+        &mut self,
+        op: &ast::BinaryOperator,
+        lhs: VisitorResult,
+        rhs: VisitorResult,
+    ) -> VisitorResult {
+        let lhs_handle = lhs.result_handle.unwrap();
+        let rhs_handle = rhs.result_handle.unwrap();
+        let result_register = self.generate_tmp_variable();
+
+        let operation = match op {
+            And(_) => format!(
+                "{} = and i1 {}, {}\n",
+                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            Or(_) => format!(
+                "{} = or i1 {}, {}\n",
+                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            EqualEqual(_) => format!(
+                "{} = icmp eq i1 {}, {}\n",
+                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            NotEqual(_) => format!(
+                "{} = icmp ne i1 {}, {}\n",
+                result_register, lhs_handle.llvm_name, rhs_handle.llvm_name
+            ),
+            _ => panic!("Unsupported boolean operator"),
+        } + "\n";
+
+        VisitorResult {
+            preamble: lhs.preamble + &rhs.preamble + &operation,
+            result_handle: Some(LlvmHandle::new_i1_register(result_register)),
+        }
+    }
+}

--- a/generator/src/visitor/helpers/control_flow.rs
+++ b/generator/src/visitor/helpers/control_flow.rs
@@ -1,0 +1,35 @@
+use crate::GeneratorVisitor;
+
+impl GeneratorVisitor {
+    /// # Description
+    ///
+    /// Will format input as follows:
+    ///
+    /// format!("br i1 {condition_handle}, label %{true_label_name}, label %{false_label_name}")
+    pub(crate) fn branch_choice_statement(
+        &self,
+        condition_handle: &str,
+        true_label_name: &str,
+        false_label_name: &str,
+    ) -> String {
+        format!("br i1 {condition_handle}, label %{true_label_name}, label %{false_label_name}\n")
+    }
+
+    /// # Description
+    ///
+    /// Will format input as follows:
+    ///
+    /// format!("br label %{label_name}")
+    pub(crate) fn branch_jump_statement(&self, label_name: &str) -> String {
+        format!("br label %{label_name}\n")
+    }
+
+    /// # Description
+    ///
+    /// Will format input as follows:
+    ///
+    /// format!("{label_name}:\n")
+    pub(crate) fn block_start(&self, label_name: &str) -> String {
+        format!("{label_name}:\n")
+    }
+}

--- a/generator/src/visitor/helpers/variables.rs
+++ b/generator/src/visitor/helpers/variables.rs
@@ -1,0 +1,69 @@
+use crate::llvm_types::LlvmHandle;
+use crate::{GeneratorVisitor, llvm_types::LlvmType};
+
+impl GeneratorVisitor {
+    pub(crate) fn generate_tmp_variable(&mut self) -> String {
+        // we use the . after % to get around llvm's requirement that %N names
+        // be sequential starting at 0 within the same context
+        let tmp_variable = format!("%.{}", self.tmp_variable_id);
+        self.tmp_variable_id += 1;
+
+        tmp_variable
+    }
+
+    pub(crate) fn alloca_statement(&self, var_register_name: &str, var_type: &LlvmType) -> String {
+        let (type_name, align_size) = self.type_name_and_align_size(var_type);
+
+        format!("{var_register_name} = alloca {type_name}, align {align_size}\n")
+    }
+
+    pub(crate) fn load_statement(
+        &self,
+        source_var_register_name: &str,
+        target_register_name: &str,
+        var_type: &LlvmType,
+    ) -> String {
+        let (type_name, align_size) = self.type_name_and_align_size(var_type);
+
+        format!(
+            "{target_register_name} = load {type_name}, {type_name}* {source_var_register_name}, align {align_size}\n"
+        )
+    }
+
+    pub(crate) fn extract_variable_value_to_register(
+        &self,
+        target_register_name: String,
+        source_var_register_name: &str,
+        var_type: &LlvmType,
+    ) -> (String, LlvmHandle) {
+        let preamble =
+            self.load_statement(source_var_register_name, &target_register_name, var_type);
+
+        let result_handle = match var_type {
+            LlvmType::F64 => LlvmHandle::new_f64_register(target_register_name),
+            LlvmType::I1 => LlvmHandle::new_i1_register(target_register_name),
+        };
+
+        (preamble, result_handle)
+    }
+
+    pub(crate) fn store_statement(
+        &self,
+        source_register_name: &str,
+        target_var_register_name: &str,
+        var_type: &LlvmType,
+    ) -> String {
+        let (type_name, align_size) = self.type_name_and_align_size(var_type);
+
+        format!(
+            "store {type_name} {source_register_name}, {type_name}* {target_var_register_name}, align {align_size}\n"
+        )
+    }
+
+    pub(crate) fn type_name_and_align_size(&self, llvm_type: &LlvmType) -> (&str, u32) {
+        match llvm_type {
+            LlvmType::F64 => ("double", 8),
+            LlvmType::I1 => ("i1", 1),
+        }
+    }
+}

--- a/generator/src/visitor/if_else.rs
+++ b/generator/src/visitor/if_else.rs
@@ -1,0 +1,146 @@
+use crate::llvm_types::LlvmHandle;
+
+use super::{GeneratorVisitor, VisitorResult};
+
+impl GeneratorVisitor {
+    pub(crate) fn handle_if_else(
+        &mut self,
+        condition_result: VisitorResult,
+        then_result: VisitorResult,
+        else_result: VisitorResult,
+    ) -> VisitorResult {
+        let condition_preamble = condition_result.preamble;
+        let condition_result_handle_name = condition_result
+            .result_handle
+            .expect("Expected result handle for condition of if expression")
+            .llvm_name;
+
+        match (then_result.result_handle, else_result.result_handle) {
+            (Some(then_result_handle), Some(else_result_handle)) => self.handle_returning_if_else(
+                &condition_preamble,
+                &condition_result_handle_name,
+                &then_result.preamble,
+                &then_result_handle,
+                &else_result.preamble,
+                &else_result_handle,
+            ),
+            (None, None) => self.handle_none_returning_if_else(
+                condition_preamble,
+                &condition_result_handle_name,
+                &then_result.preamble,
+                &else_result.preamble,
+            ),
+            _ => panic!(
+                "Detected if expression with different return types, SA should have caught this"
+            ),
+        }
+    }
+
+    fn handle_none_returning_if_else(
+        &mut self,
+        condition_preamble: String,
+        condition_result_handle_name: &str,
+        then_preamble: &str,
+        else_preamble: &str,
+    ) -> VisitorResult {
+        let (then_label, else_label, fi_label) = self.generate_then_else_fi_labels();
+
+        let condition_setup = condition_preamble
+            + &self.branch_choice_statement(condition_result_handle_name, &then_label, &else_label);
+
+        let then_branch =
+            self.block_start(&then_label) + then_preamble + &self.branch_jump_statement(&fi_label);
+
+        let else_branch =
+            self.block_start(&else_label) + else_preamble + &self.branch_jump_statement(&fi_label);
+
+        let final_block = self.block_start(&fi_label);
+
+        let preamble = condition_setup + &then_branch + &else_branch + &final_block;
+
+        return VisitorResult {
+            result_handle: None,
+            preamble,
+        };
+    }
+
+    fn handle_returning_if_else(
+        &mut self,
+        condition_preamble: &str,
+        condition_result_handle_name: &str,
+        then_preamble: &str,
+        then_result_handle: &LlvmHandle,
+        else_preamble: &str,
+        else_result_handle: &LlvmHandle,
+    ) -> VisitorResult {
+        let (then_label, else_label, fi_label) = self.generate_then_else_fi_labels();
+
+        let result_var_register = self.generate_tmp_variable();
+        let result_type = then_result_handle.handle_type.inner_type();
+
+        // we create a variable to store the result (to avoid phi)
+        let condition_setup = self.alloca_statement(&result_var_register, &result_type)
+            + condition_preamble
+            + &self.branch_choice_statement(condition_result_handle_name, &then_label, &else_label);
+
+        // we create both branches, they start with their respective labels, then their preamble,
+        // and finally they store the result in the result variable
+
+        let then_branch = self.block_start(&then_label)
+            + then_preamble
+            + &self.store_statement(
+                &then_result_handle.llvm_name,
+                &result_var_register,
+                &result_type,
+            )
+            + &self.branch_jump_statement(&fi_label);
+
+        let else_branch = self.block_start(&else_label)
+            + else_preamble
+            + &self.store_statement(
+                &else_result_handle.llvm_name,
+                &result_var_register,
+                &result_type,
+            )
+            + &self.branch_jump_statement(&fi_label);
+
+        // finally, we extract the result into a new register in the final block
+
+        let result_register = self.generate_tmp_variable();
+
+        let (result_load_preamble, result_handle) = self.extract_variable_value_to_register(
+            result_register,
+            &result_var_register,
+            &result_type,
+        );
+
+        let final_block = self.block_start(&fi_label) + &result_load_preamble;
+
+        let preamble = condition_setup + &then_branch + &else_branch + &final_block;
+
+        return VisitorResult {
+            result_handle: Some(result_handle),
+            preamble,
+        };
+    }
+
+    /// # Description
+    ///
+    /// Uses the same global tmp_variable id to create globally unique then, else, fi
+    /// labels, used for if expressions
+    ///
+    /// # Examples
+    ///
+    /// - If we generate a temporary variable %.0, and then generate these labels, we'll get
+    /// then.1, else.1, fi.1
+    /// - If we generate the labels first, we'll get then.0, else.0, fi.0
+    pub(crate) fn generate_then_else_fi_labels(&mut self) -> (String, String, String) {
+        let t = format!("then.{}", self.tmp_variable_id);
+        let e = format!("else.{}", self.tmp_variable_id);
+        let f = format!("fi.{}", self.tmp_variable_id);
+
+        self.tmp_variable_id += 1;
+
+        (t, e, f)
+    }
+}

--- a/generator/src/visitor/print.rs
+++ b/generator/src/visitor/print.rs
@@ -1,0 +1,85 @@
+use crate::llvm_types::{self, HandleType, LlvmType};
+
+use super::{GeneratorVisitor, VisitorResult};
+
+impl GeneratorVisitor {
+    pub(crate) fn instantiate_global_print_helpers(&self) -> String {
+        "@.fstr = private constant [3 x i8] c\"%f\\00\", align 1\n".to_string()
+            + "@.true_str = private constant [5 x i8] c\"true\\00\", align 1\n"
+            + "@.false_str = private constant [6 x i8] c\"false\\00\", align 1\n"
+            + "@.none_str = private constant [5 x i8] c\"none\\00\", align 1\n"
+            + "declare i32 @printf(i8*, ...)\n"
+    }
+
+    pub(crate) fn handle_print(&mut self, inner_result: VisitorResult) -> VisitorResult {
+        let preamble = inner_result.preamble
+            + &match inner_result.result_handle {
+                Some(handle) => match handle.handle_type {
+                    HandleType::Register(LlvmType::F64) | HandleType::Literal(LlvmType::F64) => {
+                        self.print_double(&handle.llvm_name)
+                    }
+                    HandleType::Literal(LlvmType::I1) => {
+                        if handle.llvm_name == llvm_types::TRUE_LITERAL_STR {
+                            self.print_true()
+                        } else {
+                            self.print_false()
+                        }
+                    }
+                    HandleType::Register(LlvmType::I1) => {
+                        self.print_boolean_register(&handle.llvm_name)
+                    }
+                },
+                None => self.print_none(),
+            };
+
+        VisitorResult {
+            preamble,
+            result_handle: None,
+        }
+    }
+
+    fn print_true(&mut self) -> String {
+        let element_ptr = self.generate_tmp_variable();
+        format!(
+            "{} = getelementptr [5 x i8], [5 x i8]* @.true_str, i32 0, i32 0\n",
+            element_ptr
+        ) + &format!("call i32 (i8*, ...) @printf(i8* {})\n", element_ptr)
+    }
+
+    fn print_false(&mut self) -> String {
+        let element_ptr = self.generate_tmp_variable();
+        format!(
+            "{} = getelementptr [6 x i8], [6 x i8]* @.false_str, i32 0, i32 0\n",
+            element_ptr
+        ) + &format!("call i32 (i8*, ...) @printf(i8* {})\n", element_ptr)
+    }
+
+    fn print_boolean_register(&mut self, handle: &str) -> String {
+        let (then, else_, fi) = self.generate_then_else_fi_labels();
+        format!("br i1 {handle}, label %{then}, label %{else_}\n")
+            + &format!("{then}:\n")
+            + &self.print_true()
+            + &format!("br label %{fi}\n")
+            + &format!("{else_}:\n")
+            + &self.print_false()
+            + &format!("br label %{fi}\n")
+            + &format!("{fi}:\n")
+    }
+
+    fn print_double(&mut self, handle: &str) -> String {
+        let element_ptr_variable = self.generate_tmp_variable();
+
+        format!(
+            "{} = getelementptr inbounds [3 x i8], [3 x i8]* @.fstr, i32 0, i32 0\ncall i32 (i8*, ...) @printf(i8* {}, double {})\n",
+            element_ptr_variable, element_ptr_variable, handle
+        )
+    }
+
+    fn print_none(&mut self) -> String {
+        let element_ptr = self.generate_tmp_variable();
+        format!(
+            "{} = getelementptr [5 x i8], [5 x i8]* @.none_str, i32 0, i32 0\n",
+            element_ptr
+        ) + &format!("call i32 (i8*, ...) @printf(i8* {})\n", element_ptr)
+    }
+}

--- a/generator/src/visitor/while_exp.rs
+++ b/generator/src/visitor/while_exp.rs
@@ -1,0 +1,59 @@
+use super::{GeneratorVisitor, VisitorResult};
+
+impl GeneratorVisitor {
+    pub(crate) fn handle_while(
+        &mut self,
+        condition_result: VisitorResult,
+        body_result: VisitorResult,
+    ) -> VisitorResult {
+        let condition_result_handle = condition_result
+            .result_handle
+            .expect("Expected a result handle for condition of while statement");
+
+        let (loop_label, body_label, loop_exit_label) = self.generate_loop_labels();
+
+        // here we assume the type of the handle returned by the condition is i1, SA is
+        // responsible for this
+        let loop_setup = self.branch_jump_statement(&loop_label)
+            + &self.block_start(&loop_label)
+            + &condition_result.preamble
+            + &self.branch_choice_statement(
+                &condition_result_handle.llvm_name,
+                &body_label,
+                &loop_exit_label,
+            );
+
+        let body_code = self.block_start(&body_label)
+            + &body_result.preamble
+            + &self.branch_jump_statement(&loop_label);
+
+        let exit_code = self.block_start(&loop_exit_label);
+
+        let preamble = loop_setup + &body_code + &exit_code;
+
+        VisitorResult {
+            preamble,
+            result_handle: None,
+        }
+    }
+
+    /// # Description
+    ///
+    /// Uses the same global tmp_variable id to create globally unique loop, body,
+    /// loop_exit labels
+    ///
+    /// # Examples
+    ///
+    /// - If we generate a temporary variable %.0, and then generate these labels, we'll get
+    /// loop.1, body.1, loop_exit.1
+    /// - If we generate the labels first, we'll get loop.0, body.0, loop_exit.0
+    fn generate_loop_labels(&mut self) -> (String, String, String) {
+        let l = format!("loop.{}", self.tmp_variable_id);
+        let b = format!("body.{}", self.tmp_variable_id);
+        let le = format!("loop_exit.{}", self.tmp_variable_id);
+
+        self.tmp_variable_id += 1;
+
+        (l, b, le)
+    }
+}


### PR DESCRIPTION
add support for pretty printing boolean values

add type handling in define_or_shadow (before, it assumed definitions were of f64)

fix loop label inversion