### PR TITLE
fix(parser): make dassignment lhs atom

### DIFF
--- a/ast/src/ast/expressions/destructive_assignment.rs
+++ b/ast/src/ast/expressions/destructive_assignment.rs
@@ -5,17 +5,17 @@ use crate::{
 };
 
 pub struct DestructiveAssignment {
-    pub identifier: Identifier,
+    pub lhs: Box<Expression>,
     pub op: BinaryOperator,
-    pub expression: Box<Expression>,
+    pub rhs: Box<Expression>,
 }
 
 impl DestructiveAssignment {
-    pub fn new(identifier: Identifier, op: BinaryOperator, rhs: Expression) -> Self {
+    pub fn new(lhs: Expression, op: BinaryOperator, rhs: Expression) -> Self {
         DestructiveAssignment {
-            identifier,
+            lhs: Box::new(lhs),
             op,
-            expression: Box::new(rhs),
+            rhs: Box::new(rhs),
         }
     }
 }

--- a/generator/src/visitor.rs
+++ b/generator/src/visitor.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 
 use crate::context::Context;
 use crate::llvm_types::{LlvmHandle, LlvmType};
-use ast::{ExpressionVisitor, VisitableExpression};
+use ast::{Expression, ExpressionVisitor, VisitableExpression};
 
 pub struct VisitorResult {
     pub result_handle: Option<LlvmHandle>,
@@ -101,20 +101,25 @@ impl ExpressionVisitor<VisitorResult> for GeneratorVisitor {
         &mut self,
         node: &mut ast::DestructiveAssignment,
     ) -> VisitorResult {
-        let expression_result = node.expression.accept(self);
+        let expression_result = node.rhs.accept(self);
         let mut preamble = expression_result.preamble;
 
         let exp_result_handle = expression_result.result_handle.expect(
             "Variable must be dassigned to non-null expression result, SA should've caught this",
         );
 
+        let variable = match node.lhs.as_ref() {
+            Expression::Variable(var) => var,
+            _ => todo!()
+        };
+
         let var_llvm_name = &self
             .context
-            .get_value(&node.identifier.id)
+            .get_value(&variable.id)
             .expect(
                 format!(
                     "Variable {} not found, SA should have caught this",
-                    node.identifier.id
+                    variable.id
                 )
                 .as_str(),
             )

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -220,8 +220,8 @@ pub Expression: ast::Expression = {
 }
 
 DestructiveAssignment: ast::DestructiveAssignment = {
-    <id:Identifier> <o:ColonAssignOp> <e:Expression>
-        => ast::DestructiveAssignment::new(id, o, e),
+    <l:Atom> <o:ColonAssignOp> <r:Expression>
+        => ast::DestructiveAssignment::new(l, o, r),
 }
 
 

--- a/parser/src/test/expression_parser/destructive_assignment.rs
+++ b/parser/src/test/expression_parser/destructive_assignment.rs
@@ -1,0 +1,88 @@
+use crate::grammar::ExpressionParser;
+
+#[test]
+fn simple_dassignment() {
+    let p = ExpressionParser::new();
+
+    let answ = p.parse("a := 3").unwrap();
+
+    assert_eq!(
+        answ.as_destructive_assignment()
+            .unwrap()
+            .lhs
+            .as_variable()
+            .unwrap()
+            .id,
+        "a"
+    );
+    assert_eq!(
+        answ.as_destructive_assignment()
+            .unwrap()
+            .rhs
+            .as_number_literal()
+            .unwrap()
+            .value,
+        3.0
+    );
+}
+
+#[test]
+fn data_member_dassignment() {
+    let p = ExpressionParser::new();
+
+    let answ = p.parse("o.m := 3").unwrap();
+
+    assert_eq!(
+        answ.as_destructive_assignment()
+            .unwrap()
+            .lhs
+            .as_data_member_access()
+            .unwrap()
+            .object
+            .as_variable()
+            .unwrap()
+            .id,
+        "o"
+    );
+    assert_eq!(
+        answ.as_destructive_assignment()
+            .unwrap()
+            .lhs
+            .as_data_member_access()
+            .unwrap()
+            .member
+            .id,
+        "m"
+    );
+    assert_eq!(
+        answ.as_destructive_assignment()
+            .unwrap()
+            .rhs
+            .as_number_literal()
+            .unwrap()
+            .value,
+        3.0
+    );
+}
+
+#[test]
+fn complex_member_reassignment() {
+    let p = ExpressionParser::new();
+
+    let answ = p.parse("a.b.get_c().d := w").unwrap();
+
+    assert_eq!(
+        answ.as_destructive_assignment()
+            .unwrap()
+            .lhs
+            .as_data_member_access()
+            .unwrap()
+            .object
+            .as_function_member_access()
+            .unwrap()
+            .member
+            .identifier
+            .id,
+        "get_c"
+    )
+}

--- a/parser/src/test/expression_parser/mod.rs
+++ b/parser/src/test/expression_parser/mod.rs
@@ -18,5 +18,6 @@ mod functions;
 mod function_member;
 mod data_member;
 
+mod destructive_assignment;
 
 

--- a/parser/src/visitors/echo_visitor/echo_visitor.rs
+++ b/parser/src/visitors/echo_visitor/echo_visitor.rs
@@ -40,8 +40,9 @@ impl ExpressionVisitor<String> for EchoVisitor {
     }
 
     fn visit_destructive_assignment(&mut self, node: &mut ast::DestructiveAssignment) -> String {
-        let expression = node.expression.accept(self);
-        format!("{} {} {}", node.identifier, node.op, expression)
+        let assignee = node.lhs.accept(self);
+        let expression = node.rhs.accept(self);
+        format!("{} {} {}", assignee, node.op, expression)
     }
 
     fn visit_bin_op(&mut self, node: &mut ast::BinOp) -> String {


### PR DESCRIPTION
This will allow expressions such as `object.member := 3`