### PR TITLE
refactor: 💡 Refactor Semantic Visitor

### DIFF
--- a/semantic_analyzer/src/test/type_definition.rs
+++ b/semantic_analyzer/src/test/type_definition.rs
@@ -1001,7 +1001,7 @@ fn mutate_field_in_list_incorrect_typing() {
 
     assert_eq!(
         result.err().unwrap(),
-        vec!["Type mismatch: Member array is Number but is being assigned Number*".to_string()]
+        vec!["Type mismatch: Cannot assign Number* to Number".to_string()]
     );
 }
 
@@ -1129,5 +1129,32 @@ fn unknown_annotation_in_type_arg() {
     assert_eq!(
         result.err().unwrap(),
         vec!["Semantic Error: Type or protocol Boniato is not defined.".to_string(),]
+    );
+}
+
+#[test]
+fn reassign_nonexisting_property() {
+    let p = ProgramParser::new();
+
+    let mut answ = p
+        .parse(
+            "
+            type A {
+                x=3;
+            }
+            let a = new A() in {
+                a.y := 1;
+            };
+        ",
+        )
+        .unwrap();
+
+    let mut semantic_analyzer = SemanticAnalyzer::new();
+
+    let result = semantic_analyzer.analyze_program_ast(&mut answ);
+
+    assert_eq!(
+        result.err().unwrap(),
+        vec!["Could not find data member y".to_string()]
     );
 }

--- a/semantic_analyzer/src/visitors/mod.rs
+++ b/semantic_analyzer/src/visitors/mod.rs
@@ -5,4 +5,4 @@ pub mod global_definer_visitor;
 pub use global_definer_visitor::GlobalDefinerVisitor;
 
 pub mod semantic_visitor;
-pub use semantic_visitor::SemanticVisitor;
+pub(crate) use semantic_visitor::SemanticVisitor;

--- a/semantic_analyzer/src/visitors/semantic_visitor/destructive_assignment.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/destructive_assignment.rs
@@ -1,0 +1,111 @@
+use ast::{
+    Identifier,
+    typing::{TypeAnnotation, to_string},
+};
+
+use super::SemanticVisitor;
+
+impl<'a> SemanticVisitor<'a> {
+    /// # Description
+    /// Handles the semantic analysis for variable reassignment.
+    /// It checks if the variable is defined, if it is a constant, and if the types conform.
+    /// It also collects any semantic errors encountered during the analysis.
+    /// # Arguments
+    /// - `variable`: A reference to the `Identifier` representing the variable being reassigned.
+    /// - `assignee_type`: A reference to the `TypeAnnotation` representing the type of the value being assigned.
+    /// - `expr_type`: A reference to the `TypeAnnotation` representing the type of the expression being assigned.
+    /// # Returns
+    /// A `TypeAnnotation` representing the type of the assignment if valid, or the type of the expression if there is a semantic error.
+    pub(crate) fn handle_reassign_var(
+        &mut self,
+        variable: &Identifier,
+        assignee_type: &TypeAnnotation,
+        expr_type: &TypeAnnotation,
+    ) -> TypeAnnotation {
+        let variable_id = variable.id.clone();
+        let def_value = self.var_definitions.get_value(&variable_id);
+        match def_value {
+            None => {
+                let message = format!("Variable {} is not defined", variable_id);
+                self.errors.push(message);
+                expr_type.clone()
+            }
+            Some(def) if def.is_constant => {
+                let message = format!(
+                    "Semantic Error: `{}` is not a valid assignment target",
+                    variable_id
+                );
+
+                self.errors.push(message);
+                assignee_type.clone()
+            }
+            Some(def) if !self.type_checker.conforms(&expr_type, &def.ty) => {
+                let message = format!(
+                    "Type mismatch: {} is {} but is being reassigned with {}",
+                    variable_id,
+                    to_string(&def.ty),
+                    to_string(&expr_type)
+                );
+                self.errors.push(message);
+                assignee_type.clone()
+            }
+            Some(_) => assignee_type.clone(),
+        }
+    }
+
+    /// # Description
+    /// Handles the semantic analysis for field reassignment.
+    /// It checks if the field is defined, if it is a constant, and if the types conform.
+    /// It also collects any semantic errors encountered during the analysis.
+    /// # Arguments
+    /// - `field`: A reference to the `Identifier` representing the field being reassigned.
+    /// - `assignee_type`: A reference to the `TypeAnnotation` representing the type of the value being assigned.
+    /// - `expr_type`: A reference to the `TypeAnnotation` representing the type of the expression being assigned.
+    /// # Returns
+    /// A `TypeAnnotation` representing the type of the assignment if valid, or the type of the expression if there is a semantic error.
+    /// # Notes
+    /// This function does not check if the field is accessible, assumes that that has been done previously.
+    pub(crate) fn handle_field_reassign(
+        &mut self,
+        field: &Identifier,
+        assignee_type: &TypeAnnotation,
+        expr_type: &TypeAnnotation,
+    ) -> TypeAnnotation {
+        let member_name = field.id.clone();
+        if !self.type_checker.conforms(&expr_type, &assignee_type) {
+            let message = format!(
+                "Type mismatch: {} is {} but is being reassigned with {}",
+                member_name,
+                to_string(&field.info.ty),
+                to_string(&expr_type)
+            );
+            self.errors.push(message);
+        }
+        assignee_type.clone()
+    }
+
+    /// # Description
+    /// Handles the semantic analysis for list element reassignment.
+    /// It checks if the types conform for the reassignment of a list element.
+    /// It also collects any semantic errors encountered during the analysis.
+    /// # Arguments
+    /// - `assignee_type`: A reference to the `TypeAnnotation` representing the type of the list element being assigned.
+    /// - `expr_type`: A reference to the `TypeAnnotation` representing the type of the expression being assigned to the list element.
+    /// # Returns
+    /// A `TypeAnnotation` representing the type of the assignment if valid, or the type of the expression if there is a semantic error.
+    pub(crate) fn handle_list_element_reassign(
+        &mut self,
+        assignee_type: &TypeAnnotation,
+        expr_type: &TypeAnnotation,
+    ) -> TypeAnnotation {
+        if !self.type_checker.conforms(&expr_type, &assignee_type) {
+            let message = format!(
+                "Type mismatch: Cannot assign {} to list element of type {}",
+                to_string(&expr_type),
+                to_string(&assignee_type)
+            );
+            self.errors.push(message);
+        }
+        assignee_type.clone()
+    }
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor/find_member_info.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/find_member_info.rs
@@ -1,0 +1,55 @@
+use ast::typing::TypeAnnotation;
+
+use crate::def_info::DefinitionInfo;
+
+use super::SemanticVisitor;
+
+impl<'a> SemanticVisitor<'a> {
+    /// # Description
+	/// `find_member_info` searches for a member's definition information
+	/// within a type definition or its parent types.
+	/// It traverses the type hierarchy, looking for the specified member name.
+	/// # Parameters
+	/// - `member_name`: The name of the member to search for.
+	/// - `ty`: The type annotation to start the search from.
+	/// - `with_lookup`: A boolean indicating whether to look up in the inheritance tree.
+	/// # Returns
+	/// - `Option<&DefinitionInfo>`: Returns an `Option` containing a reference to the `DefinitionInfo`
+	/// if the member is found, or `None` if it is not found.
+    pub(crate) fn find_member_info(
+        &self,
+        member_name: String,
+        ty: &TypeAnnotation,
+        with_lookup: bool,
+    ) -> Option<&DefinitionInfo> {
+        let mut current_type = ty.clone();
+        loop {
+            let Some(ty) = &current_type else { break };
+
+            let type_name = ty.to_string();
+            let type_def = self.type_definitions.get_value(&type_name);
+
+            if let Some(type_def) = type_def.and_then(|d| d.as_defined()) {
+                if let Some(info) = type_def.members.get(&member_name) {
+                    return Some(info);
+                }
+
+                // If we are not looking up in the inheritance tree, we can stop here
+                if !with_lookup {
+                    return None;
+                }
+
+                // Try parent type
+                let parent_type = self.type_hierarchy.get(&type_name).cloned().expect(&format!(
+                   "Type name {} is not found in type tree, this should not happen in semantic visitor",
+                    type_name 
+                ));
+                current_type = parent_type;
+                continue;
+            }
+            current_type = None;
+        }
+        None
+    }
+    
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor/function_call.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/function_call.rs
@@ -1,0 +1,39 @@
+use ast::{Expression, Identifier, VisitableExpression, typing::TypeAnnotation};
+
+use crate::def_info::FuncInfo;
+
+use super::SemanticVisitor;
+
+impl<'a> SemanticVisitor<'a> {
+    /// # Description
+    /// Handles the semantic analysis for function calls.
+    /// It checks if the function is defined, if the arguments conform to the expected types,
+    /// and sets the type of the identifier to the return type of the function. It also collects any semantic errors encountered during the analysis.
+    /// # Arguments
+    /// - `fn_info`: A reference to the `FuncInfo` containing information about the function being called.
+    /// - `identifier`: A mutable reference to the `Identifier` representing the function call.
+    /// - `arguments`: A mutable reference to a vector of `Expression` representing the arguments passed to the function.
+    /// # Returns
+    /// A `TypeAnnotation` representing the return type of the function call.
+    pub(crate) fn handle_function_call(
+        &mut self,
+        fn_info: FuncInfo,
+        identifier: &mut Identifier,
+        arguments: &mut Vec<Expression>,
+    ) -> TypeAnnotation {
+        let fn_info = fn_info.clone();
+
+        let parameter_types: Vec<TypeAnnotation> =
+            arguments.iter_mut().map(|arg| arg.accept(self)).collect();
+        let fn_check_result = self
+            .type_checker
+            .check_functor_call(&fn_info, &parameter_types);
+        if let Err(errors) = fn_check_result {
+            for error in errors {
+                self.errors.push(error);
+            }
+        }
+        identifier.set_type_if_none(*fn_info.get_functor_type().return_type.clone());
+        *fn_info.get_functor_type().return_type.clone()
+    }
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor/function_def.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/function_def.rs
@@ -1,0 +1,100 @@
+use ast::{
+    FunctionDef, TypeName, VisitableExpression,
+    typing::{TypeAnnotation, to_string},
+};
+
+use crate::def_info::VarInfo;
+
+use super::SemanticVisitor;
+
+impl<'a> SemanticVisitor<'a> {
+    /// # Description
+    /// Handles the semantic analysis for function definitions.
+    /// Defines the function parameters in the variable definitions,
+    /// checks the body of the function, and verifies that the return type matches the expected type.
+    /// It also collects any semantic errors encountered during the analysis.
+    /// # Arguments
+    /// - `fn_def`: A mutable reference to the `FunctionDef` representing the function being defined in the AST.
+    /// - `enclosing_type_name`: An optional reference to the `TypeName` of the enclosing type, if the function is a method of a type.
+    /// # Returns
+    /// A `TypeAnnotation` representing the return type of the function definition.
+    pub(crate) fn handle_fn_def(
+        &mut self,
+        fn_def: &mut FunctionDef,
+        enclosing_type_name: Option<&TypeName>,
+    ) -> TypeAnnotation {
+        let mut has_invalid_annotations = false;
+        match self.get_conformable(&fn_def.identifier.info.ty) {
+            Ok(_) => {}
+            Err(message) => {
+                self.errors.push(message);
+                has_invalid_annotations = true;
+            }
+        };
+
+        for param in &fn_def.parameters {
+            self.var_definitions.define(
+                param.id.clone(),
+                VarInfo::new_from_identifier(param, true, None),
+            );
+            match self.get_conformable(&param.info.ty) {
+                Ok(_) => {}
+                Err(message) => {
+                    self.errors.push(message);
+                    has_invalid_annotations = true;
+                }
+            };
+        }
+
+        // If has invalid annotations skip the method checking
+        if has_invalid_annotations {
+            return None;
+        }
+
+        let body_type = fn_def.body.accept(self);
+
+        let fn_info = match enclosing_type_name {
+            Some(type_name) => {
+                self.type_definitions
+                    .get_value_mut(&type_name.id)
+                    .and_then(|d| d.as_defined_mut())
+                    .expect(&format!(
+                        "Type {} is not defined, this should not happen in Semantic visitor",
+                        &type_name.id
+                    ))
+                    .members
+                    .get_mut(&fn_def.identifier.id)
+                    .and_then(|d| d.as_func_mut())
+                    .expect(&format!(
+                        "Method {} is not defined in type {}, this should not happen in Semantic visitor",
+                        &fn_def.identifier.id, &type_name.id
+                ))
+            }
+            None => {
+                self.func_definitions
+                    .get_value_mut(&fn_def.identifier.id)
+                    .expect(&format!(
+                        "Function {} is not defined, this should not happen in Semantic visitor",
+                        &fn_def.identifier.id,
+                    ))
+            }
+        };
+
+        if !self
+            .type_checker
+            .conforms(&body_type, &fn_info.get_functor_type().return_type)
+        {
+            self.errors.push(format!(
+                "Type mismatch: Function {} returns {} but {} was found",
+                fn_def.identifier.id,
+                to_string(&fn_info.get_functor_type().return_type),
+                to_string(&body_type)
+            ));
+        }
+        // annotate the function identifier with return type in the AST
+        fn_def.identifier.set_type_if_none(body_type.clone());
+        // annotate the function identifier with return type in the info
+        fn_info.name.set_type_if_none(body_type.clone());
+        None
+    }
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor/get_conformable.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/get_conformable.rs
@@ -1,0 +1,31 @@
+use ast::typing::{Type, TypeAnnotation};
+
+use super::SemanticVisitor;
+
+impl<'a> SemanticVisitor<'a> {
+    pub(crate) fn get_conformable(
+        &self,
+        annotation: &TypeAnnotation,
+    ) -> Result<TypeAnnotation, String> {
+        let ty = if let Some(annotation) = annotation.as_ref() {
+            annotation
+        } else {
+            return Ok(None);
+        };
+
+        //TODO: we probably need to do something generic for this
+        let ty = if let Type::Iterable(inner) = ty {
+            inner.as_ref()
+        } else {
+            ty
+        };
+
+        if self.type_definitions.is_defined(&ty.to_string()) {
+            return Ok(annotation.clone());
+        }
+        Err(format!(
+            "Semantic Error: Type or protocol {} is not defined.",
+            ty.to_string()
+        ))
+    }
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor/print.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/print.rs
@@ -1,0 +1,42 @@
+use ast::{
+    Expression, VisitableExpression,
+    typing::{BuiltInType, Type, TypeAnnotation, to_string},
+};
+
+use super::SemanticVisitor;
+
+impl<'a> SemanticVisitor<'a> {
+    /// # Description
+    /// Handles the semantic analysis for the `print` function.
+    /// It checks if the number of arguments is correct and if the argument type is valid.
+    /// # Arguments
+    /// - `arguments`: A mutable reference to a vector of `Expression` representing the arguments passed to the `print` function.
+    /// # Returns
+    /// A `TypeAnnotation` representing the type of the argument if it is valid, or `None` if there is a type mismatch.
+    pub(crate) fn handle_print(&mut self, arguments: &mut Vec<Expression>) -> TypeAnnotation {
+        if arguments.len() != 1 {
+            let message = format!(
+                "Type mismatch: print function expects 1 argument, but {} were provided",
+                arguments.len()
+            );
+            self.errors.push(message);
+            return None;
+        }
+        let arg_type = arguments[0].accept(self);
+        if !vec![
+            Some(Type::BuiltIn(BuiltInType::String)),
+            Some(Type::BuiltIn(BuiltInType::Number)),
+            Some(Type::BuiltIn(BuiltInType::Bool)),
+        ]
+        .contains(&arg_type)
+        {
+            let message = format!(
+                "Type mismatch: print function expects argument of type String, but {} was provided",
+                to_string(&arg_type)
+            );
+            self.errors.push(message);
+            return None;
+        }
+        return arg_type;
+    }
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor/var_definition.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/var_definition.rs
@@ -1,0 +1,62 @@
+use ast::{
+    Identifier,
+    typing::{TypeAnnotation, to_string},
+};
+
+use crate::{def_info::VarInfo, visitors::SemanticVisitor};
+
+impl<'a> SemanticVisitor<'a> {
+    /// # Description
+    /// Handles the semantic analysis for variable definitions.
+    /// It checks if the variable is already defined, if it is shadowable,
+    /// and if the type of the right-hand side conforms to the type of the variable.
+    /// Defines the variable in the variable definitions if all checks pass.
+    /// Annotates the identifier with the type of the variable and sets its definition position.
+    /// It also collects any semantic errors encountered during the analysis.
+    /// # Arguments
+    /// - `identifier`: A mutable reference to the `Identifier` representing the variable being defined.
+    /// - `right_type`: A `TypeAnnotation` representing the type of the value being assigned to the variable.
+    /// - `shadoweable`: A boolean indicating whether the variable can be shadowed (redefined) in the current scope.
+    /// # Returns
+    /// A `TypeAnnotation` representing the type of the variable if it is defined successfully, or `None` if there is a semantic error.
+    pub(crate) fn handle_var_definition(
+        &mut self,
+        identifier: &mut Identifier,
+        right_type: TypeAnnotation,
+        shadoweable: bool,
+    ) -> TypeAnnotation {
+        let var_type = match self.get_conformable(&identifier.info.ty) {
+            Ok(conformable) => conformable,
+            Err(message) => {
+                self.errors.push(message);
+                None
+            }
+        };
+
+        let is_asignable = self.type_checker.conforms(&right_type, &var_type);
+
+        if !is_asignable {
+            let message = format!(
+                "Type mismatch: Cannot assign {} to {}",
+                to_string(&right_type),
+                to_string(&identifier.info.ty)
+            );
+            self.errors.push(message);
+        }
+
+        if !shadoweable && self.var_definitions.is_defined(&identifier.id) {
+            let message = format!("Constant {} is already defined", identifier.id);
+            self.errors.push(message);
+        } else {
+            let var_info = if shadoweable {
+                VarInfo::new_from_identifier(identifier, true, right_type.clone())
+            } else {
+                VarInfo::new_constant_from_identifier(identifier, true, right_type.clone())
+            };
+            self.var_definitions.define(identifier.id.clone(), var_info);
+        }
+        identifier.set_type_if_none(right_type.clone());
+        identifier.info.definition_pos = Some(identifier.position.clone());
+        None
+    }
+}


### PR DESCRIPTION
Moved some logic of the semantic visitor into handlers in a separated
crate for a shorter code. Added docstrigns. Added one test