### PR TITLE
fix: 🐛 Properly handled field definition

### DIFF
--- a/semantic_analyzer/src/test/type_definition.rs
+++ b/semantic_analyzer/src/test/type_definition.rs
@@ -1158,3 +1158,54 @@ fn reassign_nonexisting_property() {
         vec!["Could not find data member y".to_string()]
     );
 }
+
+#[test]
+fn use_field_without_self() {
+    let p = ProgramParser::new();
+
+    let mut answ = p
+        .parse(
+            "
+            type A {
+                x=3;
+                method(): Number {
+                    x;
+                }
+            }
+        ",
+        )
+        .unwrap();
+
+    let mut semantic_analyzer = SemanticAnalyzer::new();
+
+    let result = semantic_analyzer.analyze_program_ast(&mut answ);
+
+    assert_eq!(
+        result.err().unwrap(),
+        vec!["Variable x is not defined".to_string()]
+    );
+}
+
+#[test]
+fn field_with_same_name_as_param() {
+    let p = ProgramParser::new();
+
+    let mut answ = p
+        .parse(
+            "
+            type A(x: Number) {
+                x= x;
+                method(x: Number): Number {
+                    self.x + x;
+                }
+            }
+        ",
+        )
+        .unwrap();
+
+    let mut semantic_analyzer = SemanticAnalyzer::new();
+
+    let result = semantic_analyzer.analyze_program_ast(&mut answ);
+
+    assert!(result.is_ok(), "Errors: {:?}", result.err());
+}

--- a/semantic_analyzer/src/visitors/semantic_visitor.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor.rs
@@ -411,10 +411,9 @@ impl<'a> DefinitionVisitor<TypeAnnotation> for SemanticVisitor<'a> {
         for member in &mut node.data_member_defs {
             let member_type = member.default_value.accept(self);
             
-            self.handle_var_definition(
+            self.handle_field_definition(
                 &mut member.identifier,
                 member_type.clone(),
-                true,
             );
 
             let member_info = self.type_definitions

--- a/semantic_analyzer/src/visitors/semantic_visitor/var_definition.rs
+++ b/semantic_analyzer/src/visitors/semantic_visitor/var_definition.rs
@@ -51,4 +51,25 @@ impl<'a> SemanticVisitor<'a> {
         identifier.info.definition_pos = Some(identifier.position.clone());
         None
     }
+
+    pub(crate) fn handle_field_definition(
+        &mut self,
+        identifier: &mut Identifier,
+        right_type: TypeAnnotation,
+    ) -> TypeAnnotation {
+        let is_asignable = self.type_checker.conforms(&right_type, &identifier.info.ty);
+
+        if !is_asignable {
+            let message = format!(
+                "Type mismatch: Cannot assign {} to {}",
+                to_string(&right_type),
+                to_string(&identifier.info.ty)
+            );
+            self.errors.push(message);
+        }
+
+        identifier.set_type_if_none(right_type.clone());
+        identifier.info.definition_pos = Some(identifier.position.clone());
+        None
+    }
 }


### PR DESCRIPTION
Before the change field definitios were handled as variable definition, wich means that accessing them without `self` did not resulted in error. Added tests for checking this behavior